### PR TITLE
Fixed the blocked texts on the help dialog panel

### DIFF
--- a/app/src/main/res/layout/help_dialog.xml
+++ b/app/src/main/res/layout/help_dialog.xml
@@ -1,9 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<ScrollView
+    xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
+    android:layout_height="match_parent">
+<LinearLayout
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
     android:orientation="vertical"
     android:paddingLeft="@dimen/fab_margin"
     android:paddingTop="@dimen/fab_margin"
@@ -63,3 +67,4 @@
         android:text="@string/help_sub_list_body" />
 
 </LinearLayout>
+</ScrollView>


### PR DESCRIPTION
Dear developer:

Hello! I am the creator of issue #5, and I have fixed the blocked texts on the help dialog panel. I would genuinely appreciate it if you could kindly revise my code and leave me some advice. Thank you so much for your precious time!

Here is the screenshot after my changes:

<img src="https://user-images.githubusercontent.com/25502419/131445379-9f3cfdef-b0fe-4bab-818e-c44904f950c8.png" alt="copy" width="250"/>

Thanks again! Blessings on your day! :)